### PR TITLE
Retry connection with a new header

### DIFF
--- a/src/Http/Connection.php
+++ b/src/Http/Connection.php
@@ -68,7 +68,7 @@ class Connection implements ConnectionInterface
             $responseCode = $e->getCode();
         }
 
-        if ($responseCode == 401) {
+        if ($responseCode === 401) {
             return $this->retryConnection($client, $url);
         }
 

--- a/src/Http/Connection.php
+++ b/src/Http/Connection.php
@@ -19,6 +19,9 @@ use Symplicity\Outlook\Exception\ConnectionException;
 use Symplicity\Outlook\Interfaces\Http\ConnectionInterface;
 use Symplicity\Outlook\Interfaces\Http\RequestOptionsInterface;
 use Symplicity\Outlook\Utilities\RequestType;
+use Symplicity\Accommodate\Plugins\CalendarSync\OutlookUserMapping;
+use Symplicity\Accommodate\Plugins\CalendarSync\Outlook;
+use Symplicity\Accommodate\App;
 
 class Connection implements ConnectionInterface
 {
@@ -28,6 +31,7 @@ class Connection implements ConnectionInterface
     protected $clientOptions;
     protected $responses;
     protected $logger;
+    protected $requestArgs;
 
     protected static $eventInfo = [];
 
@@ -39,9 +43,16 @@ class Connection implements ConnectionInterface
 
     public function get(string $url, RequestOptionsInterface $requestOptions, array $args = []) : ResponseInterface
     {
+        $this->requestArgs = [
+            'url' => $url,
+            'requestOptions' => $requestOptions,
+            'args' => $args,
+        ];
+
         $client = $this->createClientWithRetryHandler();
         $options = [
-            'headers' => $requestOptions->getHeaders()
+            'headers' => $requestOptions->getHeaders(),
+            'http_errors' => false,
         ];
 
         if (empty($args['skipQueryParams'])) {
@@ -49,7 +60,17 @@ class Connection implements ConnectionInterface
         }
 
         try {
-            return $client->request(RequestType::Get, $url, $options);
+            $response = $client->request(RequestType::Get, $url, $options);
+            if ($this->shouldRetry($response->getStatusCode())) {
+                $newHeader = $this->tryRefreshHeaderToken();
+                if (!empty($newHeader)) {
+                    $options['headers'] = $newHeader;
+                    $options['http_errors'] = true;
+                    $response = $client->request(RequestType::Get, $url, $options);
+                }
+            }
+
+            return $response;
         } catch (\Exception $e) {
             if ($this->logger instanceof LoggerInterface) {
                 $this->logger->warning('Get Request Failed', [
@@ -213,5 +234,39 @@ class Connection implements ConnectionInterface
     protected function shouldRetry(int $statusCode) : bool
     {
         return in_array($statusCode, [401, 403, 408, 429]) || $statusCode >= 500;
+    }
+
+    public function tryRefreshHeaderToken(): array
+    {
+        if (!empty($this->requestArgs['args']['accessToken']) 
+            && !empty($this->requestArgs['args']['RequestObj'])
+            && !empty($this->requestArgs['url'])
+            && !empty($this->requestArgs['args']['params'])) {
+
+            if (method_exists(App::class, 'getContainer')
+                && method_exists(Outlook::class, 'getToken')
+                && method_exists(Outlook::class, 'init')
+                && method_exists(OutlookUserMapping::class, 'getUserInfoByAccessToken')) {
+
+                $app = new App();
+                $c = $app->getContainer();
+                $accessToken = $this->requestArgs['args']['accessToken'];
+                $userInfo = OutlookUserMapping::getUserInfoByAccessToken($c, $accessToken);
+                if (!empty($userInfo)) {
+                    $outlook = Outlook::init($c, $userInfo['user'], $userInfo);
+                    if (!empty($outlook)) {
+                        $newAccessToken = $outlook->getToken();
+                        $requestObj = $this->requestArgs['args']['RequestObj'];
+                        $requestObj->setAccessToken($newAccessToken);
+                        $params = $this->requestArgs['args']['params'];
+                        $newHeader = $requestObj->getNewHeader($this->requestArgs['url'], $params);
+
+                        return $newHeader;
+                    }
+                }
+            }
+        }
+
+        return [];
     }
 }

--- a/src/Http/Connection.php
+++ b/src/Http/Connection.php
@@ -250,7 +250,7 @@ class Connection implements ConnectionInterface
         return [];
     }
 
-    public function setRequestHandler($requestHandler)
+    public function setRequestHandler($requestHandler) : void
     {
         $this->requestHandler = $requestHandler;
     }

--- a/src/Http/Connection.php
+++ b/src/Http/Connection.php
@@ -24,11 +24,11 @@ class Connection implements ConnectionInterface
 {
     public const MAX_RETRIES = 3;
     public const MAX_UPSERT_RETRIES = 5;
+    public $requestArgs;
 
     protected $clientOptions;
     protected $responses;
     protected $logger;
-    protected $requestArgs;
 
     protected static $eventInfo = [];
 
@@ -47,7 +47,7 @@ class Connection implements ConnectionInterface
 
         $client = $this->createClientWithRetryHandler();
         $options = [
-            'headers' => $requestOptions->getHeaders(),
+            'headers' => $requestOptions->getHeaders()
         ];
 
         if (empty($args['skipQueryParams'])) {
@@ -58,7 +58,7 @@ class Connection implements ConnectionInterface
             return $client->request(RequestType::Get, $url, $options);
         } catch (\Exception $e) {
             if ($this->logger instanceof LoggerInterface) {
-                $this->logger->warning('First Get Request Failed', [
+                $this->logger->warning('Get Request Failed', [
                     'error' => $e->getMessage(),
                     'code' => $e->getCode()
                 ]);
@@ -75,7 +75,7 @@ class Connection implements ConnectionInterface
             return $client->request(RequestType::Get, $url, ['headers' => $newHeader]);
         } catch (\Exception $e) {
             if ($this->logger instanceof LoggerInterface) {
-                $this->logger->warning('Retry Get Request Failed', [
+                $this->logger->warning('Get Request Failed', [
                     'error' => $e->getMessage(),
                     'code' => $e->getCode()
                 ]);

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -14,8 +14,9 @@ use Symplicity\Outlook\Interfaces\Http\ConnectionInterface;
 use Symplicity\Outlook\Interfaces\Http\ResponseIteratorInterface;
 use Symplicity\Outlook\Utilities\RequestType;
 use Symplicity\Outlook\Token;
+use Symplicity\Outlook\Interfaces\Http\RequestInterface;
 
-class Request
+class Request implements RequestInterface
 {
     public const OUTLOOK_VERSION = 'v2.0';
     public const OUTLOOK_ROOT_URL = 'https://outlook.office.com/api/';
@@ -223,7 +224,7 @@ class Request
     public function getHeadersWithToken(string $url, array $params = []): array
     {
         $token = isset($params['token']) ? $params['token'] : [];
-        if (isset($token['clientID']) && isset($token['clientSecret']) && isset($token['outlookProxyUrl'])) {
+        if (isset($token['clientID'], $token['clientSecret'], $token['outlookProxyUrl'])) {
             $tokenObj = new Token($token['clientID'], $token['clientSecret'], ['logger' => $params['logger']]);
             $tokenEntity = $tokenObj->refresh($token['refreshToken'], $token['outlookProxyUrl']);
             $accessToken = $tokenEntity->getAccessToken();

--- a/src/Interfaces/Http/ConnectionInterface.php
+++ b/src/Interfaces/Http/ConnectionInterface.php
@@ -7,6 +7,7 @@ namespace Symplicity\Outlook\Interfaces\Http;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symplicity\Outlook\Exception\ConnectionException;
+use Symplicity\Outlook\Interfaces\Http\RequestInterface;
 
 interface ConnectionInterface
 {
@@ -52,5 +53,5 @@ interface ConnectionInterface
     /**
      * Set Request Handler Obj
      */
-    public function setRequestHandler($requestHandler) : void;
+    public function setRequestHandler(RequestInterface $requestHandler) : void;
 }

--- a/src/Interfaces/Http/ConnectionInterface.php
+++ b/src/Interfaces/Http/ConnectionInterface.php
@@ -48,4 +48,9 @@ interface ConnectionInterface
      * @return ResponseInterface
      */
     public function delete(string $url, RequestOptionsInterface $requestOptions) : ResponseInterface;
+
+    /**
+     * Set Request Handler Obj
+     */
+    public function setRequestHandler($requestHandler) : void;
 }

--- a/src/Interfaces/Http/RequestInterface.php
+++ b/src/Interfaces/Http/RequestInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplicity\Outlook\Interfaces\Http;
+
+interface RequestInterface
+{
+}

--- a/src/Interfaces/Http/RequestInterface.php
+++ b/src/Interfaces/Http/RequestInterface.php
@@ -6,4 +6,11 @@ namespace Symplicity\Outlook\Interfaces\Http;
 
 interface RequestInterface
 {
+    /**
+     * Get Headers with refreshed token
+     * @param string $url
+     * @param array $params
+     * @return array
+     */
+    public function getHeadersWithToken(string $url, array $params = []) : array;
 }

--- a/tests/Http/ConnectionTest.php
+++ b/tests/Http/ConnectionTest.php
@@ -33,7 +33,7 @@ class ConnectionTest extends TestCase
         $logger = new Logger('outlook-calendar', [$this->handler]);
         $this->connection = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs(['logger' => $logger])
-            ->setMethods(['createClientWithRetryHandler', 'createClient', 'upsertRetryDelay'])
+            ->onlyMethods(['createClientWithRetryHandler', 'createClient', 'upsertRetryDelay'])
             ->getMock();
     }
 

--- a/tests/Http/ConnectionTest.php
+++ b/tests/Http/ConnectionTest.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symplicity\Outlook\Http\Connection;
 use Symplicity\Outlook\Http\RequestOptions;
-use Symplicity\Outlook\Interfaces\Utils\BatchResponseInterface;
+use Symplicity\Outlook\Http\Request as outlookRequest;
 use Symplicity\Outlook\Utilities\RequestType;
 
 class ConnectionTest extends TestCase
@@ -33,7 +33,7 @@ class ConnectionTest extends TestCase
         $logger = new Logger('outlook-calendar', [$this->handler]);
         $this->connection = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs(['logger' => $logger])
-            ->onlyMethods(['createClientWithRetryHandler', 'createClient', 'upsertRetryDelay'])
+            ->setMethods(['createClientWithRetryHandler', 'createClient', 'upsertRetryDelay'])
             ->getMock();
     }
 
@@ -182,5 +182,36 @@ class ConnectionTest extends TestCase
             [new Request(RequestType::Delete, 'outlook.com'), new Response(429, ['Content-Length' => 0], stream_for('Client Error')), 2, true],
             [new Request(RequestType::Delete, 'outlook.com'), new Response(429, ['Content-Length' => 0], stream_for('Client Error')), 11, false]
         ];
+    }
+
+    public function testTryRefreshHeaderToken()
+    {
+        $logger = new Logger('outlook-calendar', [$this->handler]);
+        $connectionHandler = new Connection($logger);
+        $this->assertEmpty($connectionHandler->tryRefreshHeaderToken());
+
+        $requestObj = new outlookRequest('123', ['connection' => $this->connection, 'requestOptions' => null]);
+        $connectionHandler->setRequestHandler($requestObj);
+        $connectionHandler->requestArgs = [
+            'url' => 'test.com',
+            'token' => 'test',
+        ];
+        $this->assertEmpty($connectionHandler->tryRefreshHeaderToken());
+
+        $requestObj = $this->createMock(outlookRequest::class);
+        $requestObj->method('getHeadersWithToken')
+             ->willReturn(['foo']);
+        $connectionHandler->setRequestHandler($requestObj);
+        $connectionHandler->requestArgs = [
+            'url' => 'test.com',
+            'token' => [
+                'clientID' => '123',
+                'clientSecret' => '456',
+                'refreshToken' => '789',
+                'outlookProxyUrl' => 'https://test.com/',
+            ],
+            'logger' => $logger,
+        ];
+        $this->assertEquals(['foo'], $connectionHandler->tryRefreshHeaderToken());
     }
 }

--- a/tests/Http/ConnectionTest.php
+++ b/tests/Http/ConnectionTest.php
@@ -86,7 +86,7 @@ class ConnectionTest extends TestCase
             $this->assertTrue($this->handler->hasWarningRecords());
             $this->assertTrue($this->handler->hasRecordThatMatches('/Get Request Failed/', Logger::WARNING));
             $this->assertTrue($this->handler->hasRecordThatMatches('/Retrying/', Logger::WARNING));
-            $this->assertCount(3, $this->handler->getRecords());
+            $this->assertCount(5, $this->handler->getRecords());
         }
 
         try {
@@ -96,7 +96,7 @@ class ConnectionTest extends TestCase
             $this->assertTrue($this->handler->hasWarningRecords());
             $this->assertTrue($this->handler->hasRecordThatMatches('/Get Request Failed/', Logger::WARNING));
             $this->assertTrue($this->handler->hasRecordThatMatches('/Retrying/', Logger::WARNING));
-            $this->assertCount(4, $this->handler->getRecords());
+            $this->assertCount(7, $this->handler->getRecords());
         }
     }
 

--- a/tests/Http/ConnectionTest.php
+++ b/tests/Http/ConnectionTest.php
@@ -86,7 +86,7 @@ class ConnectionTest extends TestCase
             $this->assertTrue($this->handler->hasWarningRecords());
             $this->assertTrue($this->handler->hasRecordThatMatches('/Get Request Failed/', Logger::WARNING));
             $this->assertTrue($this->handler->hasRecordThatMatches('/Retrying/', Logger::WARNING));
-            $this->assertCount(5, $this->handler->getRecords());
+            $this->assertCount(3, $this->handler->getRecords());
         }
 
         try {
@@ -96,7 +96,7 @@ class ConnectionTest extends TestCase
             $this->assertTrue($this->handler->hasWarningRecords());
             $this->assertTrue($this->handler->hasRecordThatMatches('/Get Request Failed/', Logger::WARNING));
             $this->assertTrue($this->handler->hasRecordThatMatches('/Retrying/', Logger::WARNING));
-            $this->assertCount(7, $this->handler->getRecords());
+            $this->assertCount(4, $this->handler->getRecords());
         }
     }
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -20,7 +20,7 @@ class RequestTest extends TestCase
     {
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->getMock();
 
         $request = new Request('foo', [
@@ -47,7 +47,7 @@ class RequestTest extends TestCase
     {
          $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'batch'])
+            ->onlyMethods(['get', 'batch'])
             ->getMock();
 
         $constructorArgs = [
@@ -67,7 +67,7 @@ class RequestTest extends TestCase
     {
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'batch'])
+            ->onlyMethods(['get', 'batch'])
             ->getMock();
 
         $request = new Request('foo', [

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -45,9 +45,9 @@ class RequestTest extends TestCase
 
     public function testGetHeadersWithToken()
     {
-         $connection = $this->getMockBuilder(Connection::class)
+        $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['get', 'batch'])
+            ->onlyMethods(['get'])
             ->getMock();
 
         $constructorArgs = [
@@ -67,7 +67,7 @@ class RequestTest extends TestCase
     {
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['get', 'batch'])
+            ->onlyMethods(['get'])
             ->getMock();
 
         $request = new Request('foo', [

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -42,4 +42,52 @@ class RequestTest extends TestCase
         $this->assertInstanceOf(RequestOptionsInterface::class, $requestOptions);
         $this->assertEquals(RequestType::Get, $requestOptions->getMethod());
     }
+
+    public function testGetHeadersWithToken()
+    {
+         $connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get', 'batch'])
+            ->getMock();
+
+        $constructorArgs = [
+            'requestOptions' => function () {
+                return new RequestOptions('test.com', RequestType::Get(), [
+                    'token' => 'foo'
+                ]);
+            },
+            'connection' => $connection
+        ];
+        $request = new Request('foo', $constructorArgs);
+
+        $this->assertEmpty($request->getHeadersWithToken('test.com'));
+    }
+
+    public function testGetHeaders()
+    {
+        $connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get', 'batch'])
+            ->getMock();
+
+        $request = new Request('foo', [
+            'requestOptions' => function () {
+                return new RequestOptions('test.com', RequestType::Get(), [
+                    'token' => 'foo'
+                ]);
+            },
+            'connection' => $connection
+        ]);
+
+        $this->assertNotEmpty($request->getHeaders('test.com', [
+            'headers' => [],
+            'timezone' => RequestOptions::DEFAULT_TIMEZONE,
+            'preferenceHeaders' => [],
+            'token' => '123'
+        ]));
+
+        $this->assertNotEmpty($request->getHeaders('test.com', []));
+
+        $this->assertNotEmpty($request->getHeaders('', []));
+    }
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -20,7 +20,7 @@ class RequestTest extends TestCase
     {
         $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['get'])
+            ->setMethods(['get'])
             ->getMock();
 
         $request = new Request('foo', [


### PR DESCRIPTION
It tries to refresh the access token and creates a new connection when the first one fails during the synchronization.