### PR TITLE
Factor out batch push code for reuse on app side

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -240,6 +240,13 @@ abstract class Calendar implements CalendarInterface
         $this->batchPush($eventsToWrite, $params, $args);
     }
 
+ /**
+     * @param Event[] $eventsToWrite
+     * @param array<string, string> $params
+     * @param array<string, mixed> $args
+     * @throws \JsonException
+     * @throws \Exception|\Throwable
+     */
     protected function batchPush(array $eventsToWrite, array $params = [], array $args = []): void
     {
         $this->logger?->info('Pushing batch events to outlook ...', [

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -236,6 +236,12 @@ abstract class Calendar implements CalendarInterface
      */
     public function push(array $params = [], array $args = []): void
     {
+        $eventsToWrite = $this->getLocalEvents();
+        $this->batchPush($eventsToWrite, $params, $args);
+    }
+
+    protected function batchPush(array $eventsToWrite, array $params = [], array $args = []): void
+    {
         $this->logger?->info('Pushing batch events to outlook ...', [
             'params' => http_build_query($params)
         ]);
@@ -246,7 +252,6 @@ abstract class Calendar implements CalendarInterface
 
         $batchRequestConfiguration = $this->getEventPostBatchRequestConfiguration();
 
-        $eventsToWrite = $this->getLocalEvents();
         $chunks = array_chunk($eventsToWrite, static::BATCH_BY);
 
         foreach ($chunks as $chunk) {

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -240,7 +240,7 @@ abstract class Calendar implements CalendarInterface
         $this->batchPush($eventsToWrite, $params, $args);
     }
 
- /**
+     /**
      * @param Event[] $eventsToWrite
      * @param array<string, string> $params
      * @param array<string, mixed> $args


### PR DESCRIPTION
Actual code to batch push event was factored out so that app-side can utilize this functionality without copy/override on app side.

This functionaity was needed on Advocate where we may send batch of recurrence exceptions